### PR TITLE
Fix typo in GitLab CI post

### DIFF
--- a/_posts/2021-03-22-running-kind-in-gitlab-ci-on-kubernetes.md
+++ b/_posts/2021-03-22-running-kind-in-gitlab-ci-on-kubernetes.md
@@ -15,7 +15,7 @@ excerpt: |
 
   The problem was the Helm Chart test pipeline required a nested Kubernetes environment, as our self-hosted GitLab
   runs on Kubernetes. DinD (Docker in Docker) and KinD (Kubernetes in Docker) solved the nested requirement, but
-  errors were occuring.
+  errors were occurring.
 header:
   image: /assets/images/logos/gitlab_helm_k8s.png
   teaser: /assets/images/logos/gitlab_helm_k8s.png


### PR DESCRIPTION
## Summary
- fix occuring typo in the GitLab CI on Kubernetes post

## Testing
- `bundle exec jekyll build -d /tmp/_site` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_683ff37f0c4c832a99229cf195a9381f